### PR TITLE
Memory leak in KalGridView

### DIFF
--- a/src/KalGridView.m
+++ b/src/KalGridView.m
@@ -82,6 +82,7 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
 {
   if (highlightedTile != tile) {
     highlightedTile.highlighted = NO;
+    [highlightedTile release];
     highlightedTile = [tile retain];
     tile.highlighted = YES;
     [tile setNeedsDisplay];
@@ -92,6 +93,7 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
 {
   if (selectedTile != tile) {
     selectedTile.selected = NO;
+    [selectedTile release];
     selectedTile = [tile retain];
     tile.selected = YES;
     [delegate didSelectDate:tile.date];


### PR DESCRIPTION
Fix memory leak of selectedTile and highlightedTile instances caused by their improper setter implementation (the setter should release the old value before assigning and retaining the new value).
