### PR TITLE
Use preferred locale for header month name display

### DIFF
--- a/src/KalLogic.m
+++ b/src/KalLogic.m
@@ -34,6 +34,10 @@
 {
   if ((self = [super init])) {
     monthAndYearFormatter = [[NSDateFormatter alloc] init];
+	NSString *localeString = [[NSLocale preferredLanguages] objectAtIndex:0];
+	NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:localeString];
+	[monthAndYearFormatter setLocale:locale];
+	[locale release];
     [monthAndYearFormatter setDateFormat:@"LLLL yyyy"];
     [self moveToMonthForDate:date];
   }


### PR DESCRIPTION
Month name display now uses preferred locale for display.
Before that change i always had an german name shown even when my language settings where english.
