### PR TITLE
Small change for the DataReload

### DIFF
--- a/src/KalViewController.m
+++ b/src/KalViewController.m
@@ -133,7 +133,8 @@ NSString *const KalDataSourceChangedNotification = @"KalDataSourceChangedNotific
     [dates replaceObjectAtIndex:i withObject:[KalDate dateFromNSDate:[dates objectAtIndex:i]]];
   
   [[self calendarView] markTilesForDates:dates];
-  [self didSelectDate:self.calendarView.selectedDate];
+  //Manually set the selected day so as not to fire off the delegates didSelectCalendarDate method everytime the data reloads
+  [[self calendarView] selectDate:[KalDate dateFromNSDate:self.selectedDate]];
 }
 
 // ---------------------------------------


### PR DESCRIPTION
Thanks for making this great plug-in, I've found it extremely useful for a project i'm working on now. 
I made this change locally on my copy of KalViewController:
instead of calling didSelectDate (since that will then call didSelectDate on the kalDelegate)
I think it makes more sense to tell the calendarView to set its date.

Im not sure if this is a change you'd want to add to master, or if the existing behavior was intentional. For my use case I really only need to know when a user-initiated date change occurs.

best,
Philip
