### PR TITLE
Appearance customization

### DIFF
--- a/src/KalGridView.h
+++ b/src/KalGridView.h
@@ -32,6 +32,9 @@
 @property (nonatomic, readonly) BOOL transitioning;
 @property (nonatomic, readonly) KalDate *selectedDate;
 
+// Appearance customization
+@property (nonatomic, strong) UIView *backgroundView;
+
 - (id)initWithFrame:(CGRect)frame logic:(KalLogic *)logic delegate:(id<KalViewDelegate>)delegate;
 - (void)selectDate:(KalDate *)date;
 - (void)markTilesForDates:(NSArray *)dates;

--- a/src/KalGridView.m
+++ b/src/KalGridView.m
@@ -30,6 +30,7 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
 @implementation KalGridView
 
 @synthesize selectedTile, highlightedTile, transitioning;
+@synthesize backgroundView;
 
 - (id)initWithFrame:(CGRect)frame logic:(KalLogic *)theLogic delegate:(id<KalViewDelegate>)theDelegate
 {
@@ -60,8 +61,17 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
   return self;
 }
 
+- (void)sizeToFit
+{
+  self.height = frontMonthView.height;
+}
+
+#pragma mark -
+#pragma mark Appearance
+
 - (void)drawRect:(CGRect)rect
 {
+  if (backgroundView) { return; } // backgroundView supersedes default drawing
   [[UIImage imageNamed:@"Kal.bundle/kal_grid_background.png"] drawInRect:rect];
   [[UIColor colorWithRed:0.63f green:0.65f blue:0.68f alpha:1.f] setFill];
   CGRect line;
@@ -70,10 +80,19 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
   CGContextFillRect(UIGraphicsGetCurrentContext(), line);
 }
 
-- (void)sizeToFit
+- (void)setBackgroundView:(UIView *)view
 {
-  self.height = frontMonthView.height;
+  if (backgroundView != view) {
+    [backgroundView removeFromSuperview];
+    backgroundView = view;
+    backgroundView.frame = self.bounds;
+    backgroundView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self addSubview:backgroundView];
+    [self sendSubviewToBack:backgroundView];
+    [self setNeedsDisplay]; // see drawRect:
+  }
 }
+
 
 #pragma mark -
 #pragma mark Touches
@@ -94,6 +113,7 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
     selectedTile.selected = NO;
     selectedTile = [tile retain];
     tile.selected = YES;
+    [tile.superview bringSubviewToFront:tile];
     [delegate didSelectDate:tile.date];
   }
 }

--- a/src/KalTileView.h
+++ b/src/KalTileView.h
@@ -12,28 +12,54 @@ enum {
 };
 typedef char KalTileType;
 
+enum {
+  KalTileStateNormal      = 0,
+  KalTileStateAdjacent    = 1 << 0,
+  KalTileStateToday       = 1 << 1,
+  KalTileStateSelected    = 1 << 2,
+  KalTileStateHighlighted = 1 << 3,
+  KalTileStateMarked      = 1 << 4,
+};
+typedef NSUInteger KalTileState;
+
 @class KalDate;
 
-@interface KalTileView : UIView
+@interface KalTileView : UIView<UIAppearanceContainer>
 {
   KalDate *date;
   CGPoint origin;
+  NSMutableDictionary *appearance;
   struct {
+    unsigned int type : 2;
     unsigned int selected : 1;
     unsigned int highlighted : 1;
     unsigned int marked : 1;
-    unsigned int type : 2;
   } flags;
 }
 
 @property (nonatomic, retain) KalDate *date;
+@property (nonatomic) KalTileType type;
 @property (nonatomic, getter=isHighlighted) BOOL highlighted;
 @property (nonatomic, getter=isSelected) BOOL selected;
 @property (nonatomic, getter=isMarked) BOOL marked;
-@property (nonatomic) KalTileType type;
+@property (nonatomic, getter=isToday, readonly) BOOL today;
+@property (nonatomic, readonly) BOOL belongsToAdjacentMonth;
+@property (nonatomic, readonly) KalTileState state;
 
 - (void)resetState;
-- (BOOL)isToday;
-- (BOOL)belongsToAdjacentMonth;
+
+@property (nonatomic) CGSize shadowOffset UI_APPEARANCE_SELECTOR;
+
+- (void)setReversesShadow:(NSInteger)flag forState:(KalTileState)state UI_APPEARANCE_SELECTOR;      // NSInteger instead of BOOL, in order to comply with the UIAppearanceContainer constraints
+- (void)setBackgroundImage:(UIImage *)image forState:(KalTileState)state UI_APPEARANCE_SELECTOR;    // an image that will be drawn at size {47,45}
+- (void)setMarkerImage:(UIImage *)image forState:(KalTileState)state UI_APPEARANCE_SELECTOR;        // an image that will be drawn at size {4,5}
+- (void)setTextColor:(UIColor *)color forState:(KalTileState)state UI_APPEARANCE_SELECTOR;
+- (void)setShadowColor:(UIColor *)color forState:(KalTileState)state UI_APPEARANCE_SELECTOR;
+
+- (BOOL)reversesShadowForState:(KalTileState)state UI_APPEARANCE_SELECTOR;
+- (UIImage *)backgroundImageForState:(KalTileState)state UI_APPEARANCE_SELECTOR;
+- (UIImage *)markerImageForState:(KalTileState)state UI_APPEARANCE_SELECTOR;        
+- (UIColor *)textColorForState:(KalTileState)state UI_APPEARANCE_SELECTOR;
+- (UIColor *)shadowColorForState:(KalTileState)state UI_APPEARANCE_SELECTOR;
 
 @end

--- a/src/KalTileView.m
+++ b/src/KalTileView.m
@@ -9,9 +9,120 @@
 
 extern const CGSize kTileSize;
 
+// UIAppearanceContainer
+
+static struct {
+  NSString *backgroundImage;
+  NSString *textColor;
+  NSString *shadowColor;
+  NSString *markerImage;
+  NSString *reversesShadow;
+} kAppearanceAttributes = {
+  .backgroundImage = @"backgroundImage",
+  .textColor = @"textColor",
+  .shadowColor = @"shadowColor",
+  .markerImage = @"markerImage",
+  .reversesShadow = @"reversesShadow",
+};
+static NSMutableDictionary *defaultAppearance = nil;
+
+
+// KalTileView
+
+@interface KalTileView()
++ (void)setAppearance:(NSMutableDictionary *)appearance value:(id)value forKey:(NSString *)key state:(KalTileState)state;
++ (BOOL)appearance:(NSDictionary *)appearance hasValue:(id *)outValue forKey:(NSString *)key state:(KalTileState)state;
+- (id)attributeForKey:(NSString *)key state:(KalTileState)state;
+@end
+
 @implementation KalTileView
 
 @synthesize date;
+@synthesize shadowOffset;
+
++ (void)initialize
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    
+    defaultAppearance = [[NSMutableDictionary alloc] init];
+    
+    [self setAppearance:defaultAppearance
+                  value:[[UIImage imageNamed:@"Kal.bundle/kal_tile_today.png"] stretchableImageWithLeftCapWidth:6 topCapHeight:0]
+                 forKey:kAppearanceAttributes.backgroundImage
+                  state:KalTileStateToday];
+    
+    [self setAppearance:defaultAppearance
+                  value:[[UIImage imageNamed:@"Kal.bundle/kal_tile_today_selected.png"] stretchableImageWithLeftCapWidth:6 topCapHeight:0]
+                 forKey:kAppearanceAttributes.backgroundImage
+                  state:KalTileStateToday | KalTileStateSelected];
+    
+    [self setAppearance:defaultAppearance
+                  value:[[UIImage imageNamed:@"Kal.bundle/kal_tile_selected.png"] stretchableImageWithLeftCapWidth:1 topCapHeight:0]
+                 forKey:kAppearanceAttributes.backgroundImage
+                  state:KalTileStateSelected];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIColor colorWithPatternImage:[UIImage imageNamed:@"Kal.bundle/kal_tile_text_fill.png"]]
+                 forKey:kAppearanceAttributes.textColor
+                  state:KalTileStateNormal];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIColor whiteColor]
+                 forKey:kAppearanceAttributes.textColor
+                  state:KalTileStateToday];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIColor whiteColor]
+                 forKey:kAppearanceAttributes.textColor
+                  state:KalTileStateSelected];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIColor colorWithPatternImage:[UIImage imageNamed:@"Kal.bundle/kal_tile_dim_text_fill.png"]]
+                 forKey:kAppearanceAttributes.textColor
+                  state:KalTileStateAdjacent];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIColor whiteColor]
+                 forKey:kAppearanceAttributes.shadowColor
+                  state:KalTileStateNormal];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIColor blackColor]
+                 forKey:kAppearanceAttributes.shadowColor
+                  state:KalTileStateToday];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIColor blackColor]
+                 forKey:kAppearanceAttributes.shadowColor
+                  state:KalTileStateSelected];
+    
+    [self setAppearance:defaultAppearance
+                  value:nil
+                 forKey:kAppearanceAttributes.shadowColor
+                  state:KalTileStateAdjacent];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIImage imageNamed:@"Kal.bundle/kal_marker.png"]
+                 forKey:kAppearanceAttributes.markerImage
+                  state:KalTileStateNormal];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIImage imageNamed:@"Kal.bundle/kal_marker_today.png"]
+                 forKey:kAppearanceAttributes.markerImage
+                  state:KalTileStateToday];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIImage imageNamed:@"Kal.bundle/kal_marker_selected.png"]
+                 forKey:kAppearanceAttributes.markerImage
+                  state:KalTileStateSelected];
+    
+    [self setAppearance:defaultAppearance
+                  value:[UIImage imageNamed:@"Kal.bundle/kal_marker_dim.png"]
+                 forKey:kAppearanceAttributes.markerImage
+                  state:KalTileStateAdjacent];
+  });
+}
 
 - (id)initWithFrame:(CGRect)frame
 {
@@ -22,6 +133,7 @@ extern const CGSize kTileSize;
     origin = frame.origin;
     [self setIsAccessibilityElement:YES];
     [self setAccessibilityTraits:UIAccessibilityTraitButton];
+    appearance = [[NSMutableDictionary alloc] init];
     [self resetState];
   }
   return self;
@@ -32,38 +144,18 @@ extern const CGSize kTileSize;
   CGContextRef ctx = UIGraphicsGetCurrentContext();
   CGFloat fontSize = 24.f;
   UIFont *font = [UIFont boldSystemFontOfSize:fontSize];
-  UIColor *shadowColor = nil;
-  UIColor *textColor = nil;
-  UIImage *markerImage = nil;
   CGContextSelectFont(ctx, [font.fontName cStringUsingEncoding:NSUTF8StringEncoding], fontSize, kCGEncodingMacRoman);
       
   CGContextTranslateCTM(ctx, 0, kTileSize.height);
   CGContextScaleCTM(ctx, 1, -1);
   
-  if ([self isToday] && self.selected) {
-    [[[UIImage imageNamed:@"Kal.bundle/kal_tile_today_selected.png"] stretchableImageWithLeftCapWidth:6 topCapHeight:0] drawInRect:CGRectMake(0, -1, kTileSize.width+1, kTileSize.height+1)];
-    textColor = [UIColor whiteColor];
-    shadowColor = [UIColor blackColor];
-    markerImage = [UIImage imageNamed:@"Kal.bundle/kal_marker_today.png"];
-  } else if ([self isToday] && !self.selected) {
-    [[[UIImage imageNamed:@"Kal.bundle/kal_tile_today.png"] stretchableImageWithLeftCapWidth:6 topCapHeight:0] drawInRect:CGRectMake(0, -1, kTileSize.width+1, kTileSize.height+1)];
-    textColor = [UIColor whiteColor];
-    shadowColor = [UIColor blackColor];
-    markerImage = [UIImage imageNamed:@"Kal.bundle/kal_marker_today.png"];
-  } else if (self.selected) {
-    [[[UIImage imageNamed:@"Kal.bundle/kal_tile_selected.png"] stretchableImageWithLeftCapWidth:1 topCapHeight:0] drawInRect:CGRectMake(0, -1, kTileSize.width+1, kTileSize.height+1)];
-    textColor = [UIColor whiteColor];
-    shadowColor = [UIColor blackColor];
-    markerImage = [UIImage imageNamed:@"Kal.bundle/kal_marker_selected.png"];
-  } else if (self.belongsToAdjacentMonth) {
-    textColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"Kal.bundle/kal_tile_dim_text_fill.png"]];
-    shadowColor = nil;
-    markerImage = [UIImage imageNamed:@"Kal.bundle/kal_marker_dim.png"];
-  } else {
-    textColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"Kal.bundle/kal_tile_text_fill.png"]];
-    shadowColor = [UIColor whiteColor];
-    markerImage = [UIImage imageNamed:@"Kal.bundle/kal_marker.png"];
-  }
+  int state = self.state;
+  UIColor *textColor = [self textColorForState:state];
+  UIColor *shadowColor = [self shadowColorForState:state];
+  UIImage *markerImage = [self markerImageForState:state];
+  UIImage *backgroundImage = [self backgroundImageForState:state];
+  
+  [backgroundImage drawInRect:CGRectMake(0, -1, kTileSize.width+1, kTileSize.height+1)];
   
   if (flags.marked)
     [markerImage drawInRect:CGRectMake(21.f, 5.f, 4.f, 5.f)];
@@ -77,8 +169,8 @@ extern const CGSize kTileSize;
   textY = 6.f + roundf(0.5f * (kTileSize.height - textSize.height));
   if (shadowColor) {
     [shadowColor setFill];
-    CGContextShowTextAtPoint(ctx, textX, textY, day, n >= 10 ? 2 : 1);
-    textY += 1.f;
+    int sign = [self reversesShadowForState:state] ? -1 : 1;
+    CGContextShowTextAtPoint(ctx, textX + shadowOffset.width, textY - sign * shadowOffset.height, day, n >= 10 ? 2 : 1);
   }
   [textColor setFill];
   CGContextShowTextAtPoint(ctx, textX, textY, day, n >= 10 ? 2 : 1);
@@ -103,6 +195,7 @@ extern const CGSize kTileSize;
   flags.highlighted = NO;
   flags.selected = NO;
   flags.marked = NO;
+  shadowOffset = CGSizeMake(0, 1);
 }
 
 - (void)setDate:(KalDate *)aDate
@@ -188,13 +281,146 @@ extern const CGSize kTileSize;
   [self setNeedsDisplay];
 }
 
+- (KalTileState)state { return *(int *)(&flags); }
+
+
 - (BOOL)isToday { return flags.type == KalTileTypeToday; }
 
 - (BOOL)belongsToAdjacentMonth { return flags.type == KalTileTypeAdjacent; }
 
+
+#pragma mark -
+#pragma mark Appearance
+
+- (void)setBackgroundImage:(UIImage *)image forState:(KalTileState)state
+{
+  [KalTileView setAppearance:appearance value:image forKey:kAppearanceAttributes.backgroundImage state:state];
+  [self setNeedsDisplay];
+}
+
+- (void)setMarkerImage:(UIImage *)image forState:(KalTileState)state
+{
+  [KalTileView setAppearance:appearance value:image forKey:kAppearanceAttributes.markerImage state:state];
+  [self setNeedsDisplay];
+}
+
+- (void)setTextColor:(UIColor *)color forState:(KalTileState)state
+{
+  [KalTileView setAppearance:appearance value:color forKey:kAppearanceAttributes.textColor state:state];
+  [self setNeedsDisplay];
+}
+
+- (void)setShadowColor:(UIColor *)color forState:(KalTileState)state
+{
+  [KalTileView setAppearance:appearance value:color forKey:kAppearanceAttributes.shadowColor state:state];
+  [self setNeedsDisplay];
+}
+
+- (void)setReversesShadow:(NSInteger)flag forState:(KalTileState)state
+{
+  [KalTileView setAppearance:appearance value:[NSNumber numberWithBool:flag] forKey:kAppearanceAttributes.reversesShadow state:state];
+  [self setNeedsDisplay];
+}
+
+- (UIImage *)markerImageForState:(KalTileState)state
+{
+  return [self attributeForKey:kAppearanceAttributes.markerImage state:state];
+}
+
+- (UIImage *)backgroundImageForState:(KalTileState)state
+{
+  return [self attributeForKey:kAppearanceAttributes.backgroundImage state:state];
+}
+
+- (UIColor *)textColorForState:(KalTileState)state
+{
+  return [self attributeForKey:kAppearanceAttributes.textColor state:state];
+}
+
+- (UIColor *)shadowColorForState:(KalTileState)state
+{
+  return [self attributeForKey:kAppearanceAttributes.shadowColor state:state];
+}
+
+- (BOOL)reversesShadowForState:(KalTileState)state
+{
+  return [[self attributeForKey:kAppearanceAttributes.reversesShadow state:state] boolValue];
+}
+
+- (void)setShadowOffset:(CGSize)offset
+{
+    shadowOffset = offset;
+    [self setNeedsDisplay];
+}
+
+#pragma mark -
+
++ (void)setAppearance:(NSMutableDictionary *)appearance value:(id)value forKey:(NSString *)key state:(KalTileState)state
+{
+  NSMutableDictionary *valueForState = [appearance objectForKey:key];
+  if (valueForState == nil) {
+    valueForState = [NSMutableDictionary dictionary];
+    [appearance setObject:valueForState forKey:key];
+  }
+  [valueForState setObject:(value ?: [NSNull null]) forKey:[NSNumber numberWithInt:state]];
+}
+
++ (BOOL)appearance:(NSDictionary *)appearance hasValue:(id *)outValue forKey:(NSString *)key state:(KalTileState)state
+{
+  NSDictionary *valueForState = [appearance objectForKey:key];
+  if (!valueForState) { return NO; }
+  
+  // Returns the attribute with the highest number of common bits with state
+  int maxNumberOfBits = -1;
+  id bestValue = nil;
+  
+  for (NSNumber *stateNumber in valueForState) {
+    int storedState = [stateNumber intValue];
+  
+    // does state match?
+    if ((storedState & state) != storedState) { continue; }
+  
+    // does state match more ?
+    int numberOfBits;
+    for (numberOfBits = 0; storedState; numberOfBits++) { storedState &= storedState - 1; }
+    if (numberOfBits <= maxNumberOfBits) { continue; }
+  
+    // best result so far :-)
+    maxNumberOfBits = numberOfBits;
+    bestValue = [valueForState objectForKey:stateNumber];
+  }
+  
+  if (bestValue == nil) {
+    return NO;
+  }
+  
+  if (outValue) {
+    *outValue = (bestValue == [NSNull null]) ? nil : bestValue;
+  }
+  return YES;
+}
+
+- (id)attributeForKey:(NSString *)key state:(KalTileState)state
+{
+  id value;
+  
+  if ([KalTileView appearance:appearance hasValue:&value forKey:key state:state]) {
+    return value;
+  }
+  
+  if ([KalTileView appearance:defaultAppearance hasValue:&value forKey:key state:state]) {
+    return value;
+  }
+  
+  return nil;
+}
+
+#pragma mark -
+
 - (void)dealloc
 {
   [date release];
+  [appearance release];
   [super dealloc];
 }
 


### PR DESCRIPTION
Hi. Thanks for your Kal library.

I had to customize the grid appearence.

<p><img src="https://raw.github.com/pierlis/Kal/master/Examples/CustomizedAppearance.png"></p>


This has involved changing images in Kal.bundle (uncovered by these commits), introducing a `backgroundView` property of KalGridView, and having KalTileView conform to the UIAppearanceContainer protocol.

My goal was to be able to write code like:

``` objc
@implementation MyViewController

+ (void)initialize
{
    id kalTileViewAppearance = [KalTileView appearanceWhenContainedIn:self, nil];

    UIColor *todayTextColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"Kal.bundle/kal_tile_text_fill.png"]];
    [kalTileViewAppearance setTextColor:[UIColor colorWithWhite:0.7 alpha:1]   forState:KalTileStateAdjacent];
    [kalTileViewAppearance setTextColor:[UIColor whiteColor]                   forState:KalTileStateAdjacent | KalTileStateSelected];
    [kalTileViewAppearance setTextColor:todayTextColor                         forState:KalTileStateToday];
    [kalTileViewAppearance setTextColor:[UIColor whiteColor]                   forState:KalTileStateToday | KalTileStateSelected];

    [kalTileViewAppearance setShadowColor:[UIColor whiteColor]                 forState:KalTileStateToday];
    [kalTileViewAppearance setShadowColor:[UIColor colorWithWhite:0 alpha:0.2] forState:KalTileStateSelected];
    [kalTileViewAppearance setShadowColor:[UIColor colorWithWhite:0 alpha:0.2] forState:KalTileStateToday | KalTileStateSelected];

    [kalTileViewAppearance setReversesShadow:YES                               forState:KalTileStateSelected];
}

@end
```

Let me know if you're interested.
